### PR TITLE
fix: github-readme-stats not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 
 
 ## Github
-   [![Anurag's github stats](https://github-readme-stats.vercel.app/api?username=JamesWithCode)](https://github.com/anuraghazra/github-readme-stats)
+   [![Anurag's github stats](https://github-readme-stats.vercel.app/api?username=JamesDev51)](https://github.com/anuraghazra/github-readme-stats)
 
 
 ## Problem solving


### PR DESCRIPTION
github profile의 github-readme-stats 임베드가 username 불일치로 에러가 생긴 것 같아 고쳤습니다.

* before
![image](https://github.com/JamesDev51/JamesDev51/assets/60801210/c9f2bdd0-d422-4f93-a0dc-66f63cec6fc7)

---

* after
![image](https://github.com/JamesDev51/JamesDev51/assets/60801210/6b76bc60-eeac-4f8f-8e52-838be58d7236)
